### PR TITLE
Priority greed pass rolls

### DIFF
--- a/LazyLoot/ConfigUi.cs
+++ b/LazyLoot/ConfigUi.cs
@@ -1,4 +1,3 @@
-using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Components;
 using Dalamud.Interface.Windowing;

--- a/LazyLoot/ConfigUi.cs
+++ b/LazyLoot/ConfigUi.cs
@@ -81,7 +81,6 @@ public class ConfigUi : Window, IDisposable
     private static void DrawFeatures()
     {
         ImGuiEx.ImGuiLineCentered("FeaturesLabel", () => ImGuiEx.TextUnderlined("LazyLoot Rolling Commands"));
-        ImGuiComponents.HelpMarker("These work the same as /rolling currently. However /rolling will be removed in the next update. Please update any macros you have to the new command.");
         ImGui.Columns(2, null, false);
         ImGui.SetColumnWidth(0, 80);
         ImGui.Text("/lazy need");
@@ -104,7 +103,7 @@ public class ConfigUi : Window, IDisposable
         ImGuiEx.ImGuiLineCentered("RollingDelayLabel", () => ImGuiEx.TextUnderlined("Rolling Command Delay"));
         ImGui.SetNextItemWidth(100);
 
-        if(ImGui.DragFloatRange2("Rolling delay between items", ref LazyLoot.Config.MinRollDelayInSeconds, ref LazyLoot.Config.MaxRollDelayInSeconds, 0.1f))
+        if (ImGui.DragFloatRange2("Rolling delay between items", ref LazyLoot.Config.MinRollDelayInSeconds, ref LazyLoot.Config.MaxRollDelayInSeconds, 0.1f))
         {
             LazyLoot.Config.MinRollDelayInSeconds = Math.Max(LazyLoot.Config.MinRollDelayInSeconds, 0.5f);
 
@@ -114,21 +113,14 @@ public class ConfigUi : Window, IDisposable
 
     private static void DrawUserRestriction()
     {
+        ImGui.Text("Settings in this page will apply to every single item, even if they are tradeable or not.");
         ImGui.Separator();
-        ImGui.Checkbox("Pass on items with an item level below:", ref LazyLoot.Config.RestrictionIgnoreItemLevelBelow);
-        if (LazyLoot.Config.RestrictionIgnoreItemLevelBelow)
-        {
-            ImGui.SameLine();
-            ImGui.SetNextItemWidth(100);
-            ImGui.DragInt("###ILVL", ref LazyLoot.Config.RestrictionIgnoreItemLevelBelowValue);
+        ImGui.Checkbox("Pass on items with an item level below", ref LazyLoot.Config.RestrictionIgnoreItemLevelBelow);
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(50);
+        ImGui.DragInt("###RestrictionIgnoreItemLevelBelowValue", ref LazyLoot.Config.RestrictionIgnoreItemLevelBelowValue);
+        if (LazyLoot.Config.RestrictionIgnoreItemLevelBelowValue < 0) LazyLoot.Config.RestrictionIgnoreItemLevelBelowValue = 0;
 
-            if (LazyLoot.Config.RestrictionIgnoreItemLevelBelowValue < 0)
-            {
-                LazyLoot.Config.RestrictionIgnoreItemLevelBelowValue = 0;
-            }
-        }
-
-        ImGui.TextColored(ImGuiColors.DalamudRed, "Passes on items even if they are tradeable.");
         ImGui.Checkbox("Pass on all items already unlocked. (Triple Triad Cards, Orchestrions, Faded Copies, Minions, Mounts, Emotes, Hairstyles)", ref LazyLoot.Config.RestrictionIgnoreItemUnlocked);
 
         if (!LazyLoot.Config.RestrictionIgnoreItemUnlocked)
@@ -145,6 +137,31 @@ public class ConfigUi : Window, IDisposable
         ImGui.Checkbox("Pass on items I can't use with current job.", ref LazyLoot.Config.RestrictionOtherJobItems);
 
         ImGui.Checkbox("Don't roll on items with a weekly lockout.", ref LazyLoot.Config.RestrictionWeeklyLockoutItems);
+
+        ImGui.Checkbox("###RestrictionWeeklyLockoutItems", ref LazyLoot.Config.RestrictionLootLowerThanJobIlvl);
+        ImGui.SameLine();
+        ImGui.Text("Roll");
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(80);
+        ImGui.Combo("###RestrictionLootLowerThanJobIlvlRollState", ref LazyLoot.Config.RestrictionLootLowerThanJobIlvlRollState, new string[] { "Greed", "Pass" }, 2);
+        ImGui.SameLine();
+        ImGui.Text("on items that are");
+        ImGui.SetNextItemWidth(50);
+        ImGui.SameLine();
+        ImGui.DragInt("###RestrictionLootLowerThanJobIlvlTreshold", ref LazyLoot.Config.RestrictionLootLowerThanJobIlvlTreshold);
+        if (LazyLoot.Config.RestrictionLootLowerThanJobIlvlTreshold < 0) LazyLoot.Config.RestrictionLootLowerThanJobIlvlTreshold = 0;
+        ImGui.SameLine();
+        ImGui.Text($"item levels lower than your current job item level (\u2605 {Utils.GetPlayerIlevel()}).");
+
+        ImGui.Checkbox("###RestrictionLootIsJobUpgrade", ref LazyLoot.Config.RestrictionLootIsJobUpgrade);
+        ImGui.SameLine();
+        ImGui.Text("Roll");
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(80);
+        ImGui.Combo("###RestrictionLootIsJobUpgradeRollState", ref LazyLoot.Config.RestrictionLootIsJobUpgradeRollState, new string[] { "Greed", "Pass" }, 2);
+        ImGui.SameLine();
+        ImGui.Text($"on items if the current equipped item of the same type has a higher item level.");
+
     }
 
     private void DrawChatAndToast()
@@ -166,18 +183,30 @@ public class ConfigUi : Window, IDisposable
         ImGuiEx.ImGuiLineCentered("FULFLabel", () => ImGuiEx.TextUnderlined("Fancy Ultimate Lazy Feature"));
 
         ImGui.TextWrapped($"Fancy Ultimate Lazy Feature (FULF) is a set and forget feature that will automatically roll on items for you instead of having to use the commands above.");
-        ImGui.Checkbox($"Enable FULF", ref LazyLoot.Config.FulfEnabled);
+        ImGui.Separator();
+        ImGui.Columns(2, null, false);
+        ImGui.SetColumnWidth(0, 80);
+        ImGui.Text("/fulf need");
+        ImGui.NextColumn();
+        ImGui.Text("Set FULF to Needing mode, where it will follow the /lazy need rules.");
+        ImGui.NextColumn();
+        ImGui.Text("/fulf greed");
+        ImGui.NextColumn();
+        ImGui.Text("Set FULF to Greeding mode, where it will follow the /lazy greed rules.");
+        ImGui.NextColumn();
+        ImGui.Text("/fulf pass");
+        ImGui.NextColumn();
+        ImGui.Text("Set FULF to Passing mode, where it will follow the /lazy pass rules.");
+        ImGui.NextColumn();
+        ImGui.Columns(1);
+        ImGui.Separator();
+        ImGui.Checkbox("###FulfEnabled", ref LazyLoot.Config.FulfEnabled);
+        ImGui.SameLine();
         ImGui.TextColored(LazyLoot.Config.FulfEnabled ? ImGuiColors.HealerGreen : ImGuiColors.DalamudRed, LazyLoot.Config.FulfEnabled ? "FULF Enabled" : "FULF Disabled");
 
-        ImGui.Text("Options are persistent");
-
         ImGui.SetNextItemWidth(100);
-        if (ImGui.Combo("Roll options", ref LazyLoot.Config.FulfRoll, new string[]
-        {
-        "Need",
-        "Greed",
-        "Pass",
-        }, 3))
+
+        if (ImGui.Combo("Roll options", ref LazyLoot.Config.FulfRoll, new string[] { "Need", "Greed", "Pass" }, 3))
         {
             LazyLoot.Config.Save();
         }

--- a/LazyLoot/Configuration.cs
+++ b/LazyLoot/Configuration.cs
@@ -46,6 +46,13 @@ namespace LazyLoot
         public bool RestrictionOtherJobItems = false;
         // Weekly lockout items
         public bool RestrictionWeeklyLockoutItems = false;
+        // Loot is below a certain treshhold for the current job ilvl
+        public bool RestrictionLootLowerThanJobIlvl = false;
+        public int RestrictionLootLowerThanJobIlvlTreshold = 30;
+        public int RestrictionLootLowerThanJobIlvlRollState = 1;
+        // Loot is an upgrade to the current job
+        public bool RestrictionLootIsJobUpgrade = false;
+        public int RestrictionLootIsJobUpgradeRollState = 1;
 
         public int Version { get; set; }
 

--- a/LazyLoot/LazyLoot.cs
+++ b/LazyLoot/LazyLoot.cs
@@ -1,5 +1,4 @@
-﻿using Dalamud;
-using Dalamud.Game;
+﻿using Dalamud.Game;
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.Command;
 using Dalamud.Game.Gui.Dtr;

--- a/LazyLoot/LazyLoot.cs
+++ b/LazyLoot/LazyLoot.cs
@@ -61,12 +61,6 @@ public class LazyLoot : IDalamudPlugin, IDisposable
             ShowInHelp = true,
         });
 
-        Svc.Commands.AddHandler("/rolling", new CommandInfo(RollingCommand)
-        {
-            HelpMessage = "[Obsolete, use /lazy] Roll for the loot according to the argument and the item's RollResult. /rolling need | greed | pass",
-            ShowInHelp = true,
-        });
-
         Svc.Framework.Update += OnFrameworkUpdate;
     }
 
@@ -101,7 +95,6 @@ public class LazyLoot : IDalamudPlugin, IDisposable
 
         Svc.Commands.RemoveHandler("/lazy");
         Svc.Commands.RemoveHandler("/fulf");
-        Svc.Commands.RemoveHandler("/rolling");
 
         ECommonsMain.Dispose();
         PunishLibMain.Dispose();

--- a/LazyLoot/LazyLoot.cs
+++ b/LazyLoot/LazyLoot.cs
@@ -250,8 +250,6 @@ public class LazyLoot : IDalamudPlugin, IDisposable
         string textValue = message.TextValue;
         if (textValue == Svc.Data.GetExcelSheet<LogMessage>()!.First(x => x.RowId == 5194).Text)
         {
-            Notify.Info(">>New Loot<<");
-
             _nextRollTime = DateTime.Now.AddMilliseconds(new Random()
                 .Next((int)(Config.FulfMinRollDelayInSeconds * 1000),
                 (int)(Config.FulfMaxRollDelayInSeconds * 1000)));

--- a/LazyLoot/Roller.cs
+++ b/LazyLoot/Roller.cs
@@ -202,6 +202,9 @@ internal static class Roller
             {
                 if (lootItem.LevelItem.Row < Utils.GetPlayerIlevel() - LazyLoot.Config.RestrictionLootLowerThanJobIlvlTreshold)
                 {
+                    if (LazyLoot.Config.DiagnosticsMode && LazyLoot.Config.RestrictionLootLowerThanJobIlvlRollState != 0)
+                        DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to being below your average item level and you have set to pass items below your average job item level. [Pass Item Lower Than Average iLevel]");
+
                     return LazyLoot.Config.RestrictionLootLowerThanJobIlvlRollState == 0 ? RollResult.Greeded : RollResult.Passed;
                 }
             }
@@ -224,6 +227,9 @@ internal static class Roller
                 // And we check if from the items gathered, if the lowest is higher than the droped item, we follow the rules defined by the user
                 if (itemsToVerify.Count > 0 && itemsToVerify.Min() > lootItem.LevelItem.Row)
                 {
+                    if (LazyLoot.Config.DiagnosticsMode && LazyLoot.Config.RestrictionLootIsJobUpgradeRollState != 0)
+                        DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to being below the level of your current equipped item level and you have set to pass items below the level of your equipped item. [Pass Item if equipped is of higher level]");
+
                     return LazyLoot.Config.RestrictionLootIsJobUpgradeRollState == 0 ? RollResult.Greeded : RollResult.Passed;
                 }
             }

--- a/LazyLoot/Roller.cs
+++ b/LazyLoot/Roller.cs
@@ -97,50 +97,44 @@ internal static class Roller
     }
     private unsafe static RollResult GetPlayerRestrict(LootItem loot)
     {
-        var item = Svc.Data.GetExcelSheet<Item>().GetRow(loot.ItemId);
-        if (item == null)
+        var lootItem = Svc.Data.GetExcelSheet<Item>().GetRow(loot.ItemId);
+        if (lootItem == null)
         {
             if (LazyLoot.Config.DiagnosticsMode)
                 DuoLog.Debug($"Passing due to unknown item? Please give this ID to the developers: {loot.ItemId} [Unknown ID]");
-            
             return RollResult.Passed;
         }
 
-        var lootItem = Svc.Data.GetExcelSheet<Item>().GetRow(loot.ItemId);
-        if (lootItem == null) return RollResult.Passed;
-
-        //Unique.
-        if (item.IsUnique && ItemCount(loot.ItemId) > 0) 
+        if (lootItem.IsUnique && ItemCount(loot.ItemId) > 0)
         {
             if (LazyLoot.Config.DiagnosticsMode)
-                DuoLog.Debug($"{item.Name.RawString} has been passed due to being unique and you already possess one. [Unique Item]");
-            
+                DuoLog.Debug($"{lootItem.Name.RawString} has been passed due to being unique and you already possess one. [Unique Item]");
+
             return RollResult.Passed;
         }
-        
 
         if (IsItemUnlocked(loot.ItemId))
         {
             if (LazyLoot.Config.RestrictionIgnoreItemUnlocked)
             {
                 if (LazyLoot.Config.DiagnosticsMode)
-                    DuoLog.Debug($@"{item.Name.RawString} has been passed due to being unlocked and you have ""Pass on all items already unlocked"" enabled. [Pass All Unlocked]");
+                    DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to being unlocked and you have ""Pass on all items already unlocked"" enabled. [Pass All Unlocked]");
 
                 return RollResult.Passed;
             }
 
-            if (LazyLoot.Config.RestrictionIgnoreMounts && item.ItemAction?.Value.Type == 1322)
+            if (LazyLoot.Config.RestrictionIgnoreMounts && lootItem.ItemAction?.Value.Type == 1322)
             {
                 if (LazyLoot.Config.DiagnosticsMode)
-                    DuoLog.Debug($@"{item.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Mounts"" enabled. [Pass Mounts]");
+                    DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Mounts"" enabled. [Pass Mounts]");
 
                 return RollResult.Passed;
             }
 
-            if (LazyLoot.Config.RestrictionIgnoreMinions && item.ItemAction?.Value.Type == 853)
+            if (LazyLoot.Config.RestrictionIgnoreMinions && lootItem.ItemAction?.Value.Type == 853)
             {
                 if (LazyLoot.Config.DiagnosticsMode)
-                    DuoLog.Debug($@"{item.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Minions"" enabled. [Pass Minions]");
+                    DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Minions"" enabled. [Pass Minions]");
 
                 return RollResult.Passed;
             }
@@ -149,7 +143,7 @@ internal static class Roller
                 && lootItem.ItemAction?.Value.Type == 1013)
             {
                 if (LazyLoot.Config.DiagnosticsMode)
-                    DuoLog.Debug($@"{item.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Bardings"" enabled. [Pass Bardings]");
+                    DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Bardings"" enabled. [Pass Bardings]");
 
                 return RollResult.Passed;
             }
@@ -158,7 +152,7 @@ internal static class Roller
                 && lootItem.ItemAction?.Value.Type == 2633)
             {
                 if (LazyLoot.Config.DiagnosticsMode)
-                    DuoLog.Debug($@"{item.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Emotes and Hairstyles"" enabled. [Pass Emotes/Hairstyles]");
+                    DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Emotes and Hairstyles"" enabled. [Pass Emotes/Hairstyles]");
 
                 return RollResult.Passed;
             }
@@ -167,7 +161,7 @@ internal static class Roller
                 && lootItem.ItemAction?.Value.Type == 3357)
             {
                 if (LazyLoot.Config.DiagnosticsMode)
-                    DuoLog.Debug($@"{item.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Triple Triad cards"" enabled. [Pass TTCards]");
+                    DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Triple Triad cards"" enabled. [Pass TTCards]");
 
                 return RollResult.Passed;
             }
@@ -176,7 +170,7 @@ internal static class Roller
                 && lootItem.ItemAction?.Value.Type == 25183)
             {
                 if (LazyLoot.Config.DiagnosticsMode)
-                    DuoLog.Debug($@"{item.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Orchestrion Rolls"" enabled. [Pass Orchestrion]");
+                    DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Orchestrion Rolls"" enabled. [Pass Orchestrion]");
 
                 return RollResult.Passed;
             }
@@ -185,7 +179,7 @@ internal static class Roller
                 && lootItem.Icon == 25958)
             {
                 if (LazyLoot.Config.DiagnosticsMode)
-                    DuoLog.Debug($@"{item.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Faded Copies"" enabled. [Pass Faded Copies]");
+                    DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to being unlocked and you have ""Pass on unlocked Faded Copies"" enabled. [Pass Faded Copies]");
 
                 return RollResult.Passed;
             }
@@ -225,10 +219,10 @@ internal static class Roller
             }
 
             if (LazyLoot.Config.RestrictionIgnoreItemLevelBelow
-                && item.LevelItem.Row < LazyLoot.Config.RestrictionIgnoreItemLevelBelowValue)
+                && lootItem.LevelItem.Row < LazyLoot.Config.RestrictionIgnoreItemLevelBelowValue)
             {
                 if (LazyLoot.Config.DiagnosticsMode)
-                    DuoLog.Debug($@"{item.Name.RawString} has been passed due to having ""Pass on items with an item level below"" enabled and {item.LevelItem.Row} is less than {LazyLoot.Config.RestrictionIgnoreItemLevelBelowValue}. [Pass Item Level]");
+                    DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to having ""Pass on items with an item level below"" enabled and {lootItem.LevelItem.Row} is less than {LazyLoot.Config.RestrictionIgnoreItemLevelBelowValue}. [Pass Item Level]");
 
                 return RollResult.Passed;
             }
@@ -237,7 +231,7 @@ internal static class Roller
                 && loot.RollState != RollState.UpToNeed)
             {
                 if (LazyLoot.Config.DiagnosticsMode)
-                    DuoLog.Debug($@"{item.Name.RawString} has been passed due to having ""Pass on items I can't use with current job"" and this item cannot be used with your current job. [Pass Other Job]");
+                    DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to having ""Pass on items I can't use with current job"" and this item cannot be used with your current job. [Pass Other Job]");
 
                 return RollResult.Passed;
             }
@@ -249,7 +243,7 @@ internal static class Roller
             && !(Player.Object?.ClassJob?.Id is 1 or 19))
         {
             if (LazyLoot.Config.DiagnosticsMode)
-                DuoLog.Debug($@"{item.Name.RawString} has been passed due to having ""Pass on items I can't use with current job"" and this item cannot be used with your current job. [Pass Other Job (PLD Sets)]");
+                DuoLog.Debug($@"{lootItem.Name.RawString} has been passed due to having ""Pass on items I can't use with current job"" and this item cannot be used with your current job. [Pass Other Job (PLD Sets)]");
 
             return RollResult.Passed;
         }

--- a/LazyLoot/Utils.cs
+++ b/LazyLoot/Utils.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata.Ecma335;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LazyLoot
+{
+    internal class Utils
+    {
+        public unsafe static int GetPlayerIlevel()
+        {
+            var atkArrayDataHolder = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework.Instance()->GetUiModule()->GetRaptureAtkModule()->AtkModule.AtkArrayDataHolder;
+            return atkArrayDataHolder.NumberArrays[62]->IntArray[21];
+        }
+    }
+}


### PR DESCRIPTION
![image](https://github.com/PunishXIV/LazyLoot/assets/19570528/cee1fc8c-96db-44b1-b99f-fbaee2cd79f4)

- Add the ability to pass or greed on items if the item level of the loot is a certain threshold lower than the current user job aberage item level. _Example: User job have an average item level of 636. If the user sets to pass items with a 30 item level lower, LazyLoot will automatically pass on all items for the current job that is level 610 or lower._

- Add the ability to pass or greed on items that are not straight upgrades to the items current being equipped by the user. Example: User has a ring equipped with an item level of 50 and a ring for its job drops with an item level of 40. LazyLoot will automatically apply either Pass or Greed on the item, depending on what the user selected.

- **Both settings still follow the /lazy arguments or the fulf settings stored. So, if the user configures to greed on the above settings, but FULF is set to Pass, it will preserve the fulf settings.**

- Adds an util file with functions that are shared on the entire LazyLoot project. Currently, only houses **GetPlayerIlevel**, which returns the player current average item level.

![image](https://github.com/PunishXIV/LazyLoot/assets/19570528/fc3027b9-15a1-43b6-944d-0b2b28f9fd05)

- Changed the FULF UI text, to show the fulf options and what they do, and moved the FULF indicator next to the checkbox that enables/disables it.

Resolves #3